### PR TITLE
Update `should` syntax to new `expect` syntax

### DIFF
--- a/features/step_definitions/first_steps.rb
+++ b/features/step_definitions/first_steps.rb
@@ -12,12 +12,12 @@ When /^I (?:cut|chop) (?:it|the cucumber) in (?:halves|half|two)$/ do
 end
 
 Then /^I have two cucumbers$/ do
-  @choppedCucumbers.length.should == 2
+  expect(@choppedCucumbers.length).to eq(2)
 end
 
 Then /^both are (\d+) cm long$/ do |length|
   @choppedCucumbers.each do |cuke|
-    cuke[:length].should == length.to_i
+    expect(cuke[:length]).to eq(length.to_i)
   end
 end
 


### PR DESCRIPTION
This error happens while doing your tutorial at https://blog.codecentric.de/en/2013/08/cucumber-setup-basics/
_DEPRECATION: Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead._